### PR TITLE
[chore/#2] jib 설정하여 컨테이너 이미지 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.9'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id 'com.google.cloud.tools.jib' version '3.2.1'
 }
 
 group = 'com.techeer'
@@ -26,6 +27,27 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+jib {
+	from {
+		image = "openjdk:11-jre-slim"
+		auth {
+			username = project.DOCKER_ID
+			password = project.DOCKER_PASSWORD
+		}
+	}
+	to {
+		image = project.DOCKER_ID + "/" + project.DOCKER_IMAGE_NAME
+		auth {
+			username = project.DOCKER_ID
+			password = project.DOCKER_PASSWORD
+		}
+		tags = ["latest"]
+	}
+	container {
+		jvmFlags = ["-Xms128m", "-Xmx128m"]
+	}
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 📢 기능 설명 
<img width="851" alt="스크린샷 2023-03-15 오후 5 17 55" src="https://user-images.githubusercontent.com/101381901/226097680-7ca1b463-7ec3-4429-ac5e-d7de4140bd6d.png">

jib을 이용하여 Dokerfile 대신에 도커허브에 이미지 생성하여 자바 앱 컨테이너화 

<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #2
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 