### PR TITLE
[test/#48] Book domain, 상태 별 책 조회, 독서 상태 변경 API 테스트코드 작성 

### DIFF
--- a/src/main/java/com/techeer/checkIt/domain/reading/dto/request/UpdateReadingStatusReq.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/dto/request/UpdateReadingStatusReq.java
@@ -1,12 +1,10 @@
 package com.techeer.checkIt.domain.reading.dto.request;
 
 import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateReadingStatusReq {

--- a/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
@@ -33,13 +33,14 @@ public class ReadingService {
     private final ReadingVolumeService readingVolumeService;
     private final ReadingVolumeMapper readingVolumeMapper;
 
-    public void registerReading(User user, Book book, CreateReadingReq createRequest){
+    public Long registerReading(User user, Book book, CreateReadingReq createRequest){
         ReadingStatus status = ReadingStatus.convert(createRequest.getStatus().toUpperCase());
         int lastPage = 0;
         if(status == ReadingStatus.READING) lastPage = createRequest.getLastPage();
         else if(status == ReadingStatus.READ) lastPage = book.getPages();
         Reading reading = readingMapper.toEntity(user, book, lastPage, status);
         readingRepository.save(reading);
+        return reading.getId();
     }
 
     public List<BookRes> findReadingByStatus(Long userId, ReadingStatus status) {

--- a/src/main/java/com/techeer/checkIt/domain/user/entity/User.java
+++ b/src/main/java/com/techeer/checkIt/domain/user/entity/User.java
@@ -31,6 +31,7 @@ public class User extends BaseEntity {
     private List<ReadingVolume> readingVolumeList = new ArrayList<>();
 
     @Builder
-    private User(String name) {
+    private User(Long id) {
+        this.id = id;
     }
 }

--- a/src/test/java/com/techeer/checkIt/domain/book/controller/BookControllerTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/book/controller/BookControllerTest.java
@@ -49,25 +49,24 @@ class BookControllerTest {
     }
 
     @Test
-    @DisplayName("책 제목으로 전체 책 검색")
+    @DisplayName("Controller) 책 제목으로 전체 책 검색")
     void searchTitle() throws Exception {
         List<BookRes> books = new ArrayList<>();
         books.add(TEST_BOOK);
 
-        String title = "책";
+        String title = "원";
 
         when(bookService.findBookByTitle(title)).thenReturn(books);
 
         mockMvc.perform(get("/api/v1/books/search")
                         .queryParam("title",title))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].title").value("재미있는 책"))
+                .andExpect(jsonPath("$[0].title").value("원씽"))
                 .andDo(print());
-
     }
 
     @Test
-    @DisplayName("책 id로 조회")
+    @DisplayName("Controller) 책 id로 조회")
     void getBookById() throws Exception {
 
         when(bookService.findBookById(1L)).thenReturn(TEST_BOOK);

--- a/src/test/java/com/techeer/checkIt/domain/book/controller/BookControllerTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/book/controller/BookControllerTest.java
@@ -1,20 +1,14 @@
 package com.techeer.checkIt.domain.book.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 import com.techeer.checkIt.domain.book.service.BookService;
-import com.techeer.checkIt.global.result.ResultResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;

--- a/src/test/java/com/techeer/checkIt/domain/book/controller/BookControllerTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/book/controller/BookControllerTest.java
@@ -1,0 +1,80 @@
+package com.techeer.checkIt.domain.book.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.checkIt.domain.book.dto.Response.BookRes;
+import com.techeer.checkIt.domain.book.service.BookService;
+import com.techeer.checkIt.global.result.ResultResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.techeer.checkIt.fixture.BookFixtures.TEST_BOOK;
+import static com.techeer.checkIt.fixture.BookFixtures.TEST_BOOK2;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BookController.class)
+class BookControllerTest {
+
+    @MockBean
+    private BookService bookService;
+    @Autowired
+    private MockMvc mockMvc;
+
+
+    @BeforeEach
+    void setUp(WebApplicationContext applicationContext) {
+        mockMvc =
+                MockMvcBuilders.webAppContextSetup(applicationContext)
+                        .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+                        .build();
+    }
+
+    @Test
+    @DisplayName("책 제목으로 전체 책 검색")
+    void searchTitle() throws Exception {
+        List<BookRes> books = new ArrayList<>();
+        books.add(TEST_BOOK);
+
+        String title = "책";
+
+        when(bookService.findBookByTitle(title)).thenReturn(books);
+
+        mockMvc.perform(get("/api/v1/books/search")
+                        .queryParam("title",title))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("재미있는 책"))
+                .andDo(print());
+
+    }
+
+    @Test
+    @DisplayName("책 id로 조회")
+    void getBookById() throws Exception {
+
+        when(bookService.findBookById(1L)).thenReturn(TEST_BOOK);
+        when(bookService.findBookById(2L)).thenReturn(TEST_BOOK2);
+
+        mockMvc.perform(get("/api/v1/books/{bookId}", 1L))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/techeer/checkIt/domain/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/book/repository/BookRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.techeer.checkIt.domain.book.repository;
+
+import com.techeer.checkIt.domain.book.entity.Book;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import java.util.List;
+
+import static com.techeer.checkIt.fixture.BookFixtures.BOOK_ENT;
+import static com.techeer.checkIt.fixture.BookFixtures.BOOK_ENT2;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Slf4j
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookRepositoryTest {
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Test
+    @DisplayName("Repository) 책 검색")
+    void findByTitle() {
+
+        // given
+        Book book = bookRepository.save(BOOK_ENT);  // 원씽
+        Book book2 = bookRepository.save(BOOK_ENT2);    // 불편한 편의점
+        String keyword = "원";
+
+        // when
+        List<Book> books = bookRepository.findByTitle(keyword);
+
+        // then
+        assertThat(books.get(1).getTitle()).as("책검색 결과 %s, 검색한 책 : %s",books.get(1).getTitle(), book2.getTitle()).isEqualTo(book.getTitle());
+    }
+}

--- a/src/test/java/com/techeer/checkIt/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/book/service/BookServiceTest.java
@@ -4,8 +4,6 @@ import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 import com.techeer.checkIt.domain.book.entity.Book;
 import com.techeer.checkIt.domain.book.mapper.BookMapper;
 import com.techeer.checkIt.domain.book.repository.BookRepository;
-import com.techeer.checkIt.domain.reading.repository.ReadingRepository;
-import com.techeer.checkIt.domain.reading.service.ReadingService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,9 +17,7 @@ import java.util.Optional;
 
 import static com.techeer.checkIt.fixture.BookFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +30,7 @@ class BookServiceTest {
 
     @Mock
     private BookMapper bookMapper;
-//    private final Book book = BOOK_ENT;
+
     @Test
     @DisplayName("Service) 책 제목으로 검색")
     void findBookByTitle() {
@@ -67,7 +63,7 @@ class BookServiceTest {
         given(bookRepository.findByBookId(1L)).willReturn(Optional.ofNullable(BOOK_ENT));
         when(bookMapper.toDto(BOOK_ENT)).thenReturn(bookRes);
 
-        // given
+        // when
         bookRes = bookService.findBookById(1L);
 
         // then
@@ -77,7 +73,7 @@ class BookServiceTest {
     @Test
     @DisplayName("Service) id별 판별")
     void findById() {
-
+        // given
         given(bookRepository.findById(1L)).willReturn(Optional.ofNullable(BOOK_ENT));
 
         // when

--- a/src/test/java/com/techeer/checkIt/domain/book/service/BookServiceTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/book/service/BookServiceTest.java
@@ -1,0 +1,89 @@
+package com.techeer.checkIt.domain.book.service;
+
+import com.techeer.checkIt.domain.book.dto.Response.BookRes;
+import com.techeer.checkIt.domain.book.entity.Book;
+import com.techeer.checkIt.domain.book.mapper.BookMapper;
+import com.techeer.checkIt.domain.book.repository.BookRepository;
+import com.techeer.checkIt.domain.reading.repository.ReadingRepository;
+import com.techeer.checkIt.domain.reading.service.ReadingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.techeer.checkIt.fixture.BookFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BookServiceTest {
+    @InjectMocks
+    private BookService bookService;
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private BookMapper bookMapper;
+//    private final Book book = BOOK_ENT;
+    @Test
+    @DisplayName("Service) 책 제목으로 검색")
+    void findBookByTitle() {
+        // given
+        List<Book> books = new ArrayList<>();
+        books.add(BOOK_ENT); // 원씽
+
+        List<BookRes> bookList = new ArrayList<>();
+        bookList.add(TEST_BOOK);
+        String title = "원";
+
+        given(bookRepository.findByTitle(any())).willReturn(books);
+        when(bookMapper.toDtoList(books)).thenReturn(bookList);
+
+        // when
+        bookList = bookService.findBookByTitle(title);
+
+
+        // then
+        assertThat(bookList.size()).isEqualTo(1);
+
+    }
+
+    @Test
+    @DisplayName("Service) book id로 책 조회")
+    void findBookById() {
+        // given
+        BookRes bookRes = TEST_BOOK;
+
+        given(bookRepository.findByBookId(1L)).willReturn(Optional.ofNullable(BOOK_ENT));
+        when(bookMapper.toDto(BOOK_ENT)).thenReturn(bookRes);
+
+        // given
+        bookRes = bookService.findBookById(1L);
+
+        // then
+        assertThat(bookRes.getTitle()).isEqualTo(BOOK_ENT.getTitle());
+    }
+
+    @Test
+    @DisplayName("Service) id별 판별")
+    void findById() {
+
+        given(bookRepository.findById(1L)).willReturn(Optional.ofNullable(BOOK_ENT));
+
+        // when
+        Book book = bookService.findById(1L);
+
+        // then
+        assertThat(book.getTitle()).isEqualTo(BOOK_ENT.getTitle());
+    }
+}

--- a/src/test/java/com/techeer/checkIt/domain/reading/controller/ReadingControllerTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/reading/controller/ReadingControllerTest.java
@@ -1,0 +1,91 @@
+package com.techeer.checkIt.domain.reading.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techeer.checkIt.domain.book.service.BookService;
+import com.techeer.checkIt.domain.reading.service.ReadingService;
+import com.techeer.checkIt.domain.readingVolume.service.ReadingVolumeService;
+import com.techeer.checkIt.domain.user.service.UserService;
+import com.techeer.checkIt.global.result.ResultResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.*;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+import static com.techeer.checkIt.fixture.BookFixtures.TEST_BOOK;
+import static com.techeer.checkIt.fixture.ReadingFixtures.TEST_READING;
+import static com.techeer.checkIt.fixture.UserFixtures.TEST_USER;
+import static com.techeer.checkIt.global.result.ResultCode.READING_CREATE_SUCCESS;
+import static com.techeer.checkIt.global.result.ResultCode.READING_PERCENTAGE_SUCCESS;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+
+@WebMvcTest
+public class ReadingControllerTest {
+    @MockBean
+    private BookService bookService;
+    @MockBean
+    private UserService userService;
+    @MockBean
+    private ReadingService readingService;
+    @MockBean
+    private ReadingVolumeService readingVolumeService;
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext applicationContext) {
+        mockMvc =
+                MockMvcBuilders.webAppContextSetup(applicationContext)
+                        .addFilter(new CharacterEncodingFilter(StandardCharsets.UTF_8.name(), true))
+                        .build();
+    }
+    private String toJsonString(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+
+    @Test
+    @DisplayName("내 서재의 책을 등록한다.")
+    void createReading() throws Exception {
+//        when(userService.findUserById(any())).thenReturn(TEST_USER);
+//        when(bookService.findBookById(any())).thenReturn(TEST_BOOK);
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders.post("/api/v1/readings/{uid}",1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJsonString(TEST_READING)))
+                .andExpect(status().isOk())
+                .andExpect(content().string(toJsonString(ResultResponse.of(READING_CREATE_SUCCESS))))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("책을 얼만큼 읽었는지 퍼센트를 계산해준다.")
+    void getPercentage() throws Exception {
+        when(userService.findUserById(any())).thenReturn(TEST_USER);
+        when(bookService.findBookById(any())).thenReturn(TEST_BOOK);
+//        when(readingService.findReadingByUserAndBook(any(),any())).thenReturn(TEST_READING);
+        mockMvc
+                .perform(
+                        MockMvcRequestBuilders.get("/api/v1/readings/percentages/{uid}",1L)
+                                .param("bid","1"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(toJsonString(ResultResponse.of(READING_PERCENTAGE_SUCCESS))))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/techeer/checkIt/domain/reading/service/ReadingServiceTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/reading/service/ReadingServiceTest.java
@@ -1,0 +1,82 @@
+package com.techeer.checkIt.domain.reading.service;
+
+import com.techeer.checkIt.domain.book.dto.Response.BookRes;
+import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingStatusReq;
+import com.techeer.checkIt.domain.reading.entity.Reading;
+import com.techeer.checkIt.domain.reading.mapper.ReadingMapper;
+import com.techeer.checkIt.domain.reading.repository.ReadingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.techeer.checkIt.domain.reading.entity.ReadingStatus.READ;
+import static com.techeer.checkIt.domain.reading.entity.ReadingStatus.READING;
+import static com.techeer.checkIt.fixture.BookFixtures.*;
+import static com.techeer.checkIt.fixture.ReadingFixtures.*;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReadingServiceTest{
+    @InjectMocks
+    private ReadingService readingService;
+    @Mock
+    private ReadingRepository readingRepository;
+
+    @Mock
+    private ReadingMapper readingMapper;
+
+    @Test
+    @DisplayName("Service) 상태 별 책 조회")
+    void findReadingByStatus() {
+        // given
+        List<Reading> readings = new ArrayList<>();
+        readings.add(TEST_READING);
+        readings.add(TEST_READING2);
+
+        List<BookRes> bookListByStatus  = new ArrayList<>();
+        bookListByStatus.add(TEST_BOOK);
+        bookListByStatus.add(TEST_BOOK2);
+
+        given(readingRepository.findByUserIdAndStatus(1L, READING)).willReturn(readings);
+        when(readingMapper.toDtoList(readings)).thenReturn(bookListByStatus);
+
+        // when
+        bookListByStatus  = readingService.findReadingByStatus(1L, READING);
+
+        // then
+        assertThat(bookListByStatus.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Service) 독서 상태 변경")
+    void updateReadingStatus() {
+        // given
+        UpdateReadingStatusReq updateStatusToRead = TEST_UPDATE_READ_REQ;       // READ로 변경
+        UpdateReadingStatusReq updateStatusToReading = TEST_UPDATE_READING_REQ; // READIING으로 변경
+        UpdateReadingStatusReq updateStatusToUnread = TEST_UPDATE_UNREAD_REQ;   // UNREAD로 변경
+
+        given(readingRepository.findByUserIdAndBookIdAndStatus(any(), any(), any())).willReturn(Optional.ofNullable(TEST_READING));
+
+        // when
+        readingService.updateReadingStatus(1L, 1L, READING, updateStatusToRead);
+        readingService.updateReadingStatus(1L, 1L, READ, updateStatusToReading);
+        readingService.updateReadingStatus(1L, 1L, READING, updateStatusToUnread);
+
+
+        // then
+        assertThat(updateStatusToRead.getLastPage()).isEqualTo(TEST_READING.getBook().getPages());
+        assertThat(updateStatusToReading.getLastPage()).isEqualTo(130);
+        assertThat(updateStatusToUnread.getLastPage()).isEqualTo(0);
+
+    }
+}

--- a/src/test/java/com/techeer/checkIt/fixture/BookFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/BookFixtures.java
@@ -1,25 +1,51 @@
 package com.techeer.checkIt.fixture;
 
 import com.techeer.checkIt.domain.book.dto.Response.BookRes;
+import com.techeer.checkIt.domain.book.entity.Book;
+
 public class BookFixtures {
     public static final BookRes TEST_BOOK =
             BookRes.builder()
-                    .author("작가")
-                    .title("재미있는 책")
-                    .coverImageUrl("imageurl.com")
-                    .height(300)
-                    .width(200)
+                    .author("게리 켈러, 제이 파파산")
+                    .title("원씽")
+                    .coverImageUrl("https://image.yes24.com/goods/9349031/XL")
+                    .height(280)
+                    .width(210)
                     .thickness(20)
-                    .publisher("일이삼 출판사")
+                    .publisher("비즈니스북스")
                     .build();
     public static final BookRes TEST_BOOK2 =
             BookRes.builder()
-                    .author("작가")
-                    .title("재미있는 북")
-                    .coverImageUrl("imageurl.com")
-                    .height(300)
-                    .width(200)
+                    .author("김호연")
+                    .title("불편한 편의점")
+                    .coverImageUrl("https://image.yes24.com/goods/117030338/L'")
+                    .height(280)
+                    .width(135)
                     .thickness(20)
-                    .publisher("일이삼 출판사")
+                    .publisher("비즈니스북스")
+                    .build();
+    public static final Book BOOK_ENT =
+            Book.builder()
+                    .author("게리 켈러, 제이 파파산")
+                    .title("원씽")
+                    .coverImageUrl("https://image.yes24.com/goods/9349031/XL")
+                    .height(280)
+                    .width(210)
+                    .thickness(20)
+                    .publisher("비즈니스북스")
+                    .pages(148)
+                    .category("자기계발")
+                    .build();
+    public static final Book BOOK_ENT2 =
+            Book.builder()
+                    .author("김호연")
+                    .title("불편한 편의점")
+                    .coverImageUrl("https://image.yes24.com/goods/117030338/L'")
+                    .height(280)
+                    .width(135)
+                    .thickness(20)
+                    .publisher("비즈니스북스")
+                    .pages(268)
+                    .category("자기계발")
                     .build();
 }

--- a/src/test/java/com/techeer/checkIt/fixture/BookFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/BookFixtures.java
@@ -1,12 +1,21 @@
 package com.techeer.checkIt.fixture;
 
 import com.techeer.checkIt.domain.book.dto.Response.BookRes;
-
 public class BookFixtures {
     public static final BookRes TEST_BOOK =
             BookRes.builder()
                     .author("작가")
                     .title("재미있는 책")
+                    .coverImageUrl("imageurl.com")
+                    .height(300)
+                    .width(200)
+                    .thickness(20)
+                    .publisher("일이삼 출판사")
+                    .build();
+    public static final BookRes TEST_BOOK2 =
+            BookRes.builder()
+                    .author("작가")
+                    .title("재미있는 북")
                     .coverImageUrl("imageurl.com")
                     .height(300)
                     .width(200)

--- a/src/test/java/com/techeer/checkIt/fixture/BookFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/BookFixtures.java
@@ -1,0 +1,16 @@
+package com.techeer.checkIt.fixture;
+
+import com.techeer.checkIt.domain.book.dto.Response.BookRes;
+
+public class BookFixtures {
+    public static final BookRes TEST_BOOK =
+            BookRes.builder()
+                    .author("작가")
+                    .title("재미있는 책")
+                    .coverImageUrl("imageurl.com")
+                    .height(300)
+                    .width(200)
+                    .thickness(20)
+                    .publisher("일이삼 출판사")
+                    .build();
+}

--- a/src/test/java/com/techeer/checkIt/fixture/ReadingFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/ReadingFixtures.java
@@ -1,0 +1,13 @@
+package com.techeer.checkIt.fixture;
+
+import com.techeer.checkIt.domain.reading.dto.request.CreateReadingReq;
+
+public class ReadingFixtures {
+    public static final CreateReadingReq TEST_READING =
+            CreateReadingReq.builder()
+                    .bookId(1L)
+                    .lastPage(30)
+                    .status("READING")
+                    .build();
+}
+

--- a/src/test/java/com/techeer/checkIt/fixture/ReadingFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/ReadingFixtures.java
@@ -1,13 +1,45 @@
 package com.techeer.checkIt.fixture;
 
-import com.techeer.checkIt.domain.reading.dto.request.CreateReadingReq;
+import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingStatusReq;
+import com.techeer.checkIt.domain.reading.entity.Reading;
+
+import static com.techeer.checkIt.domain.reading.entity.ReadingStatus.*;
+import static com.techeer.checkIt.fixture.BookFixtures.BOOK_ENT;
+import static com.techeer.checkIt.fixture.BookFixtures.BOOK_ENT2;
+import static com.techeer.checkIt.fixture.UserFixtures.TEST_USER;
 
 public class ReadingFixtures {
-    public static final CreateReadingReq TEST_READING =
-            CreateReadingReq.builder()
+    public static final UpdateReadingStatusReq TEST_UPDATE_READ_REQ =
+            UpdateReadingStatusReq.builder()
                     .bookId(1L)
-                    .lastPage(30)
-                    .status("READING")
+                    .lastPage(148)
+                    .status(READ)
+                    .build();
+    public static final UpdateReadingStatusReq TEST_UPDATE_READING_REQ =
+            UpdateReadingStatusReq.builder()
+                    .bookId(1L)
+                    .lastPage(130)
+                    .status(READING)
+                    .build();
+    public static final UpdateReadingStatusReq TEST_UPDATE_UNREAD_REQ =
+            UpdateReadingStatusReq.builder()
+                    .bookId(1L)
+                    .lastPage(0)
+                    .status(UNREAD)
+                    .build();
+
+    public static final Reading TEST_READING =
+            Reading.builder()
+                    .user(TEST_USER)
+                    .book(BOOK_ENT)
+                    .lastPage(100)
+                    .build();
+    public static final Reading TEST_READING2 =
+            Reading.builder()
+                    .user(TEST_USER)
+                    .book(BOOK_ENT2)
+                    .lastPage(120)
+                    .status(READING)
                     .build();
 }
 

--- a/src/test/java/com/techeer/checkIt/fixture/UserFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/UserFixtures.java
@@ -1,0 +1,10 @@
+package com.techeer.checkIt.fixture;
+
+import com.techeer.checkIt.domain.user.entity.User;
+
+public class UserFixtures {
+    public static final User TEST_USER =
+            User.builder()
+                    .name("테스트")
+                    .build();
+}

--- a/src/test/java/com/techeer/checkIt/fixture/UserFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/UserFixtures.java
@@ -5,6 +5,6 @@ import com.techeer.checkIt.domain.user.entity.User;
 public class UserFixtures {
     public static final User TEST_USER =
             User.builder()
-                    .name("테스트")
+                    .id(1L)
                     .build();
 }


### PR DESCRIPTION
## 📢 기능 설명 
### BookControllerTest, ServiceTest
<img width="417" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/d262f347-c41e-49bb-b233-f5667da542e0">

<br>

### ReadingServiceTest (상태 별 책 조회, 독서 상태 변경)
<img width="286" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/68e121a9-86ea-44a4-b726-6bdb978bba5b">
<img width="1039" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/ceab22e3-f981-472b-9ccf-cd3876ed0b7b">

<br>

### ReadingControllerTest (상태 별 책 조회, 독서 상태 변경)
<img width="285" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/1b165e5a-6788-4957-93e4-6bb8abecd495">
<img width="521" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/73623949-377d-41da-8dea-e1cb93f1138b">

    
<br>

## 연결된 issue
close #48 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 