### PR TITLE
[test/#70] 마지막 페이지 가져오기 및 퍼센트 계산 테스트 코드 작성

### DIFF
--- a/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
@@ -87,7 +87,7 @@ public class ReadingService {
 
     public UpdateLastPageAndPercentageRes findReadingByUserAndBook(User user, Book book) {
         Reading reading = readingRepository.findByUserAndBook(user,book).orElseThrow(ReadingNotFoundException::new);
-        double percentage = Math.round((double) reading.getLastPage() / book.getPages() * 100 * 100.0) / 100.0;
+        double percentage = calcPercentage(reading.getLastPage(), book.getPages());
         UpdateLastPageAndPercentageRes updateLastPageAndPercentageRes = readingMapper
                 .toUpdateLastPageAndPercentageResDto(reading, percentage);
         return updateLastPageAndPercentageRes;
@@ -109,5 +109,9 @@ public class ReadingService {
             throw new PageValidationException(flag);
         }
         return result;
+    }
+
+    public double calcPercentage(int readPage, int lastPage) {
+        return Math.round((double) readPage / lastPage * 100 * 100.0) / 100.0;
     }
 }

--- a/src/test/java/com/techeer/checkIt/domain/reading/controller/ReadingControllerTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/reading/controller/ReadingControllerTest.java
@@ -71,7 +71,7 @@ public class ReadingControllerTest {
                         .build();
         user = userService.findUserById(1L);
         book = bookService.findById(1L);
-        percentage = readingService.findReadingByUserAndBook(user, book);
+        percentage = readingService.calcPercentage(TEST_READING.getLastPage(), TEST_BOOK_ENT.getPages());
     }
     private String toJsonString(Object object) throws JsonProcessingException {
         return objectMapper.writeValueAsString(object);

--- a/src/test/java/com/techeer/checkIt/fixture/ReadingVolumeFixtures.java
+++ b/src/test/java/com/techeer/checkIt/fixture/ReadingVolumeFixtures.java
@@ -1,6 +1,7 @@
 package com.techeer.checkIt.fixture;
 
 import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingAndReadingVolumeReq;
+import com.techeer.checkIt.domain.reading.dto.response.UpdateLastPageAndPercentageRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateReadingAndReadingVolumeRes;
 import com.techeer.checkIt.domain.readingVolume.dto.response.SearchReadingVolumesRes;
 import com.techeer.checkIt.domain.readingVolume.entity.ReadingVolume;
@@ -10,8 +11,11 @@ import java.time.LocalDate;
 import static com.techeer.checkIt.fixture.UserFixtures.TEST_USER;
 
 public class ReadingVolumeFixtures {
-    public static final double TEST_READINGVOLUME =
-            10.0;
+    public static final UpdateLastPageAndPercentageRes TEST_READINGVOLUME = UpdateLastPageAndPercentageRes.builder()
+            .percentage(11.0)
+            .lastPage(81)
+            .build();
+
     public static final double TEST_READINGVOLUME2 =
             15.0;
 


### PR DESCRIPTION
## 📢 기능 설명 
1. 퍼센트 계산 메소드를 따로 생성해 테스트 진행 -> dto를 반환하는 경우에는 null이 반환되어 퍼센트를 비교할 수 없음, double을 반환하는 퍼센트 계산 메소드 생성
<img width="947" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/84628898/9598fbb1-be60-409f-88bc-47a321fc69f5">

<img width="612" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/84628898/4fd137ae-ba3e-4f53-ad4d-c21b79c71660">

2. reading 중복 확인 테스트 추가
<img width="958" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/84628898/beb9a75e-b2fc-4dae-bc52-a0167ed9cab6">

테스트 성공
<img width="1772" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/84628898/c62b69c1-b19e-48b6-8c9c-d1f5830ff480">


<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #70 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 