### PR TITLE
[chore/#67] monstache, elasticsearch 도커세팅 및 설정 파일 작성하여 색인 확인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ out/
 .DS_Store
 
 gradle.properties
+.env
+data
+elasticsearch
+mongodb

--- a/config/config.toml.template
+++ b/config/config.toml.template
@@ -1,0 +1,28 @@
+mongo-url = "MongoDB Atlas 주소"
+elasticsearch-urls = ["http://elasticsearch:9200"]
+direct-read-namespaces = ["database_name.collection_name"]
+dropped-collections = false
+dropped-databases = false
+elasticsearch-max-conns = 4
+elasticsearch-max-seconds = 5
+elasticsearch-max-bytes = 800000
+verbose = true
+namespace-regex = "^database_name"
+
+[[mapping]]
+namespace = "database_name.collection_name"
+index = "book"
+
+[[script]]    # ES index명 설정
+namespace = "database_name.collection_name"
+script = """
+module.exports = function(doc) {
+    var newdoc = {
+        title : doc.title,
+        author : doc.author,
+        publisher : doc.publisher,
+        category : doc.category,
+    }
+    return newdoc;
+}
+"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,92 @@
+version: "3"
+services:
+  mysql:
+    container_name: mysql
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    volumes:
+      - ./data:/var/lib/mysql
+    command:
+      - '--character-set-server=utf8mb4'
+      - '--collation-server=utf8mb4_unicode_ci'
+    ports:
+      - "3307:3306"
+    networks:
+      - default_bridge
+
+  backend:
+    container_name: backend
+    image: ${SPRING_BOOT_IMAGE}
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: ${MYSQL_URL}
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+    depends_on:
+      - mysql
+    networks:
+      default_bridge:
+        ipv4_address: 172.16.1.5
+
+  elasticsearch:
+    restart: always
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.1
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - ES_JAVA_OPTS=-Xms2048m -Xmx2048m
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ./elasticsearch/data:/usr/share/elasticsearch/data
+    networks:
+      - default_bridge
+
+  kibana:
+    restart: always
+    image: docker.elastic.co/kibana/kibana:8.8.1
+    expose:
+      - 5601
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch
+    environment:
+      - SERVER_PORT=5601
+      - SERVER_NAME=kibana.example.org
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    networks:
+      - default_bridge
+
+  monstache:
+    restart: always
+    image: rwynn/monstache:rel6
+    command: -f ./config.toml &
+    volumes:
+      - ./config/config.toml:/config.toml
+    depends_on:
+      - elasticsearch
+    links:
+      - elasticsearch
+    ports:
+      - "8081:8081"
+    networks:
+      - default_bridge
+
+networks:
+  default_bridge:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24


### PR DESCRIPTION
## 📢 기능 설명 
<img width="837" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/13206356-48f8-4e3c-b07c-928c8c01bcaf">

- Atlas를 이용하였기 때문에 MongoDB 컨테이너를 실행할 필요가 없다. 
- config.toml은 템플릿으로 파일 해뒀고 수정해야한다.
- Elasticsearch 도커 세팅 완료
<br>

## 연결된 issue
close #67 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 