### PR TITLE
[fix/#101] 프론트엔드 요구사항 수정 및 도커 네트워크 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,7 @@ services:
     #    depends_on:
     #      - mysql
     networks:
-      default_bridge:
-        ipv4_address: 172.16.1.5
+      - default_bridge
 
   #  redis:
   #    container_name: redis
@@ -109,7 +108,6 @@ services:
       - default_bridge
 
   redis-cluster-entry:
-    network_mode: "service:redis-master-1"
     image: redis
     container_name: redis-cluster
     command: redis-cli --cluster create redis-master-1:7001 redis-master-2:7002 redis-master-3:7003 redis-slave-1:7101 redis-slave-2:7102 redis-slave-3:7103 --cluster-replicas 1 --cluster-yes
@@ -124,6 +122,7 @@ services:
       - redis-slave-3
 
   elasticsearch:
+    container_name: elasticsearch
     restart: always
     image: docker.elastic.co/elasticsearch/elasticsearch:8.8.1
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,50 +1,12 @@
 version: "3"
 services:
-  #  mysql:
-  #    container_name: mysql
-  #    image: mysql:latest
-  #    environment:
-  #      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-  #      MYSQL_USER: ${MYSQL_USER}
-  #      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-  #      MYSQL_DATABASE: ${MYSQL_DATABASE}
-  #    volumes:
-  #      - ./data:/var/lib/mysql
-  #    command:
-  #      - '--character-set-server=utf8mb4'
-  #      - '--collation-server=utf8mb4_unicode_ci'
-  #    ports:
-  #      - "3307:3306"
-  #    networks:
-  #      - default_bridge
-
   backend:
     container_name: backend
     image: ${SPRING_BOOT_IMAGE}
     ports:
       - "8080:8080"
-    #    environment:
-    #      SPRING_DATASOURCE_URL: ${MYSQL_URL}
-    #      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
-    #      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-    #      SPRING_JPA_HIBERNATE_DDL_AUTO: update
-    #    depends_on:
-    #      - mysql
     networks:
       - default_bridge
-
-  #  redis:
-  #    container_name: redis
-  #    image: redis:latest
-  #    ports:
-  #      - 6379:6379
-  #    volumes:
-  #      - ./redis/data:/data
-  #    labels:
-  #      - "name=redis"
-  #      - "mode=standalone"
-  #    restart: always
-  #    command: redis-server
 
   redis-master-1:
     container_name: redis-master-1

--- a/src/main/java/com/techeer/checkIt/domain/book/dto/Response/BookRes.java
+++ b/src/main/java/com/techeer/checkIt/domain/book/dto/Response/BookRes.java
@@ -10,7 +10,7 @@ import lombok.*;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BookRes {
-    private long id;
+    private Long id;
     private String title;
     private String author;
     private String publisher;

--- a/src/main/java/com/techeer/checkIt/domain/book/mapper/BookMapper.java
+++ b/src/main/java/com/techeer/checkIt/domain/book/mapper/BookMapper.java
@@ -37,7 +37,7 @@ public class BookMapper {
                 .category(book.getCategory())
                 .build();
     }
-    public List<BookSearchRes> toDtoList(List<BookDocument> books){
+    public List<BookSearchRes> toSearchDtoList(List<BookDocument> books){
         return books.stream()
                 .map(this::toBookSearchDto)
                 .collect(Collectors.toList());

--- a/src/main/java/com/techeer/checkIt/domain/book/service/BookService.java
+++ b/src/main/java/com/techeer/checkIt/domain/book/service/BookService.java
@@ -30,7 +30,7 @@ public class BookService {
 
     public List<BookSearchRes> findBookByTitle(String title) {
         List<BookDocument> books = bookSearchRepository.findByTitleContaining(title);
-        return bookMapper.toDtoList(books);
+        return bookMapper.toSearchDtoList(books);
     }
 
     public Page<BookSearchRes> sortedBooksByTime() {

--- a/src/main/java/com/techeer/checkIt/domain/reading/controller/ReadingController.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/controller/ReadingController.java
@@ -4,6 +4,7 @@ import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 import com.techeer.checkIt.domain.book.entity.Book;
 import com.techeer.checkIt.domain.book.service.BookService;
 import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingStatusReq;
+import com.techeer.checkIt.domain.reading.dto.response.ReadingRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateLastPageAndPercentageRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateReadingAndReadingVolumeRes;
 import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
@@ -46,9 +47,9 @@ public class ReadingController {
 
     @ApiOperation(value = "상태 별 책 목록 API")
     @GetMapping("")
-    public ResponseEntity<List<BookRes>> getReadingByStatus(@AuthenticationPrincipal UserDetail userDetail, @RequestParam(defaultValue = "") ReadingStatus status) {
+    public ResponseEntity<ReadingRes> getReadingByStatus(@AuthenticationPrincipal UserDetail userDetail, @RequestParam(defaultValue = "") ReadingStatus status) {
         User user = userService.findUserByUsername(userDetail.getUsername());
-        List<BookRes> readingList = readingService.findReadingByStatus(user.getId(), status);
+        ReadingRes readingList = readingService.findReadingByStatus(user.getId(), status);
         return ResponseEntity.ok(readingList);
     }
 

--- a/src/main/java/com/techeer/checkIt/domain/reading/controller/ReadingController.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/controller/ReadingController.java
@@ -1,6 +1,5 @@
 package com.techeer.checkIt.domain.reading.controller;
 
-import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 import com.techeer.checkIt.domain.book.entity.Book;
 import com.techeer.checkIt.domain.book.service.BookService;
 import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingStatusReq;
@@ -23,9 +22,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-
 
 @Api(tags = "독서현황 API")
 @RestController

--- a/src/main/java/com/techeer/checkIt/domain/reading/dto/response/ReadingRes.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/dto/response/ReadingRes.java
@@ -1,0 +1,18 @@
+package com.techeer.checkIt.domain.reading.dto.response;
+
+import com.techeer.checkIt.domain.book.dto.Response.BookRes;
+import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReadingRes {
+    private List<BookRes> bookInfos;
+    private ReadingStatus status;
+}

--- a/src/main/java/com/techeer/checkIt/domain/reading/entity/ReadingStatus.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/entity/ReadingStatus.java
@@ -3,11 +3,11 @@ package com.techeer.checkIt.domain.reading.entity;
 import com.techeer.checkIt.domain.reading.exception.StatusNotFoundException;
 
 public enum ReadingStatus {
-    UNREAD,READING,READ;
+    LIKE,READING,READ;
     public static ReadingStatus convert(String s) {
         switch (s) {
-            case "UNREAD":
-                return ReadingStatus.UNREAD;
+            case "LIKE":
+                return ReadingStatus.LIKE;
             case "READING":
                 return ReadingStatus.READING;
             case "READ":

--- a/src/main/java/com/techeer/checkIt/domain/reading/exception/ReadingDuplicatedException.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/exception/ReadingDuplicatedException.java
@@ -1,6 +1,5 @@
 package com.techeer.checkIt.domain.reading.exception;
 
-import com.techeer.checkIt.global.error.ErrorCode;
 import com.techeer.checkIt.global.error.exception.BusinessException;
 
 import static com.techeer.checkIt.global.error.ErrorCode.READING_DUPLICATED_ERROR;

--- a/src/main/java/com/techeer/checkIt/domain/reading/mapper/ReadingMapper.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/mapper/ReadingMapper.java
@@ -3,6 +3,7 @@ package com.techeer.checkIt.domain.reading.mapper;
 import com.techeer.checkIt.domain.book.entity.Book;
 import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 
+import com.techeer.checkIt.domain.reading.dto.response.ReadingRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateLastPageAndPercentageRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateReadingAndReadingVolumeRes;
 import com.techeer.checkIt.domain.reading.entity.Reading;
@@ -38,6 +39,7 @@ public class ReadingMapper {
             .build();
     }
 
+    // TODO: int likes, boolean likeStatus 을 안 받기 때문에 값 안 가져옴
     public BookRes toDtoByBook(Book book) {
         return BookRes.builder()
             .id(book.getId())
@@ -50,12 +52,23 @@ public class ReadingMapper {
             .pages(book.getPages())
             .build();
     }
-    public List<BookRes> toDtoList(List<Reading> readings) {
-        return readings.stream().map(this::toDto).collect(Collectors.toList());
+
+    public ReadingRes toReadingList(List<Reading> readings, ReadingStatus status) {
+        List<BookRes> bookInfos = readings.stream().map(this::toDto).collect(Collectors.toList());
+
+        return ReadingRes.builder()
+                .bookInfos(bookInfos)
+                .status(status)
+                .build();
     }
 
-    public List<BookRes> toDtoListByBook(List<Book> books) {
-        return  books.stream().map(this::toDtoByBook).collect(Collectors.toList());
+    public ReadingRes toReadingListByBook(List<Book> books, ReadingStatus status) {
+        List<BookRes> bookInfos = books.stream().map(this::toDtoByBook).collect(Collectors.toList());
+
+        return ReadingRes.builder()
+                .bookInfos(bookInfos)
+                .status(status)
+                .build();
     }
 
     public UpdateReadingAndReadingVolumeRes toUpdateReadingAndReadingVolumeResDto(Reading reading, ReadingVolume readingVolume){

--- a/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
@@ -3,10 +3,12 @@ package com.techeer.checkIt.domain.reading.service;
 import com.techeer.checkIt.domain.book.dao.RedisDao;
 import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 import com.techeer.checkIt.domain.book.entity.Book;
+import com.techeer.checkIt.domain.book.mapper.BookMapper;
 import com.techeer.checkIt.domain.book.repository.BookJpaRepository;
 import com.techeer.checkIt.domain.reading.dto.request.CreateReadingReq;
 import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingAndReadingVolumeReq;
 import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingStatusReq;
+import com.techeer.checkIt.domain.reading.dto.response.ReadingRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateLastPageAndPercentageRes;
 import com.techeer.checkIt.domain.reading.dto.response.UpdateReadingAndReadingVolumeRes;
 import com.techeer.checkIt.domain.reading.entity.Reading;
@@ -56,7 +58,7 @@ public class ReadingService {
             throw  new ReadingDuplicatedException();
     }
 
-    public List<BookRes> findReadingByStatus(Long userId, ReadingStatus status) {
+    public ReadingRes findReadingByStatus(Long userId, ReadingStatus status) {
         if (status.toString().equals("UNREAD")) {
             List<Book> readings = new ArrayList<>();
             String redisUserKey = "U" + userId.toString();
@@ -64,11 +66,11 @@ public class ReadingService {
                 .map(s -> Long.parseLong(s))
                 .collect(Collectors.toList());
             readings =  bookJpaRepository.findByBookIdIn(likeBook);
-            return readingMapper.toDtoListByBook(readings);
+            return readingMapper.toReadingListByBook(readings, status);
         } else {
             List<Reading> readings = new ArrayList<>();
             readings = readingRepository.findByUserIdAndStatus(userId ,status);
-            return readingMapper.toDtoList(readings);
+            return readingMapper.toReadingList(readings, status);
         }
 
     }

--- a/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
@@ -1,9 +1,7 @@
 package com.techeer.checkIt.domain.reading.service;
 
 import com.techeer.checkIt.domain.book.dao.RedisDao;
-import com.techeer.checkIt.domain.book.dto.Response.BookRes;
 import com.techeer.checkIt.domain.book.entity.Book;
-import com.techeer.checkIt.domain.book.mapper.BookMapper;
 import com.techeer.checkIt.domain.book.repository.BookJpaRepository;
 import com.techeer.checkIt.domain.reading.dto.request.CreateReadingReq;
 import com.techeer.checkIt.domain.reading.dto.request.UpdateReadingAndReadingVolumeReq;
@@ -59,7 +57,7 @@ public class ReadingService {
     }
 
     public ReadingRes findReadingByStatus(Long userId, ReadingStatus status) {
-        if (status.toString().equals("UNREAD")) {
+        if (status.toString().equals("LIKE")) {
             List<Book> readings = new ArrayList<>();
             String redisUserKey = "U" + userId.toString();
             List<Long> likeBook = redisDao.getValuesList(redisUserKey).stream()

--- a/src/main/java/com/techeer/checkIt/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/controller/ReviewController.java
@@ -58,7 +58,7 @@ public class ReviewController {
     return ResponseEntity.ok(ResultResponse.of(ResultCode.REVIEW_CREATE_SUCCESS, reviewRes));
   }
 
-  @ApiOperation(value = "리뷰 지우기 API")
+  @ApiOperation(value = "리뷰 삭제 API")
   @DeleteMapping ("{bookId}")
   public ResponseEntity<ResultResponse> deleteReviewUserNameBookId(
       @AuthenticationPrincipal UserDetail userDetail,

--- a/src/main/java/com/techeer/checkIt/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeer/checkIt/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.techeer.checkIt.global.jwt.JwtToken;
 import com.techeer.checkIt.global.result.ResultCode;
 import com.techeer.checkIt.global.result.ResultResponse;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ public class UserController {
     private final UserService userService;
     private final AuthService authService;
 
+    @ApiOperation(value = "회원가입")
     @PostMapping("/join")
     public ResponseEntity<ResultResponse> join(
             @RequestBody @Valid UserJoinReq userJoinReq) {
@@ -34,6 +36,8 @@ public class UserController {
         userService.join(userJoinReq);
         return ResponseEntity.ok(ResultResponse.of(USER_REGISTRATION_SUCCESS));
     }
+
+    @ApiOperation(value = "아이디 중복확인")
 
     @GetMapping("/duplicated/{username}")
     public ResponseEntity<ResultResponse> isDuplicatedUsername(@PathVariable String username) {
@@ -45,18 +49,22 @@ public class UserController {
         return ResponseEntity.ok(ResultResponse.of(USER_USERNAME_NOT_DUPLICATED, false));
     }
 
+    @ApiOperation(value = "로그인")
+
     @PostMapping("/login")
     public ResponseEntity<ResultResponse> login(@RequestBody UserLoginReq userLoginReq) {
         JwtToken token = authService.login(userLoginReq.getUsername(), userLoginReq.getPassword());
         return ResponseEntity.ok(ResultResponse.of(USER_LOGIN_SUCCESS, token));
     }
 
+    @ApiOperation(value = "로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<ResultResponse> logout(@RequestBody @Valid UserTokenReq userTokenReq) {
         authService.logout(userTokenReq);
         return ResponseEntity.ok(ResultResponse.of(USER_LOGOUT_SUCCESS));
     }
 
+    @ApiOperation(value = "토큰 재발급")
     @PostMapping("/reissue")
     public ResponseEntity<ResultResponse> reissue(@RequestBody @Valid UserTokenReq userTokenReq) {
         JwtToken newToken = authService.reissue(userTokenReq);

--- a/src/main/java/com/techeer/checkIt/global/config/SecurityConfig.java
+++ b/src/main/java/com/techeer/checkIt/global/config/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)     // Security는 기본적으로 세션 사용하지만, jwt 사용할 것이기 때문에 STATELESS 로 설정
             .and()
             .authorizeRequests()
-            .antMatchers("/api/v1/users/**", "/api/v1/books/**").permitAll() // 회원가입, 로그인, 로그아웃 API는 인증 없이 허용
+            .antMatchers("/api/v1/users/join", "/api/v1/users/login", "/api/v1/users/duplicated/**",
+                                    "/api/v1/books/search").permitAll() // 회원가입, 로그인, 검색 API는 인증 없이 허용
             .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs").permitAll()
             .anyRequest().authenticated()
             .and()

--- a/src/main/java/com/techeer/checkIt/global/error/ErrorCode.java
+++ b/src/main/java/com/techeer/checkIt/global/error/ErrorCode.java
@@ -32,8 +32,8 @@ public enum ErrorCode {
     // ReadingVolume 도메인
     READING_VOLUME_NOT_FOUND_ERROR(400, "RV001", "독서추세를 찾을 수 없음"),
 
-    // Review 도메인
-    REVIEW_NOT_FOUND_ERROR(400, "RE001", "리뷰를 찾을 수 없음");
+    // 리뷰 도메인
+    REVIEW_NOT_FOUND_ERROR(400, "RE001", "리뷰를 찾을 수 없음")
     ;
 
     private final int status;

--- a/src/main/java/com/techeer/checkIt/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/techeer/checkIt/global/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public class JwtTokenProvider {
     private final CustomUserDetailService customUserDetailService;
     private final Key key;
-    private long accessTokenValidTime = 30 * 60 * 1000L; // 토큰 유효시간 30분
+    private long accessTokenValidTime = 24 * 60 * 60 * 1000L; // 토큰 유효시간 24시
     private long refreshTokenValidTime = 3 * 24 * 60 * 60 * 1000L;  // 3일
 
     // 시크릿키 초기화, secretKey를 Base64로 인코딩한다.


### PR DESCRIPTION
## 📢 기능 설명 
### 프론트엔드 요구사항 수정
![image](https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/34e891a8-f9dd-48ab-ba01-e15775721302)
- ReadingStatus enum 수정
- 반환값 수정
- 토큰 유효기간 24시로 수정 → 프론트엔드 연동할 때만
- BookId 이슈는 새로운 이슈에서 진행할 예정

### docker-compose.yml 네트워크 문제
- 백엔드 재실행 시 `docker: Error response from daemon: Address already in use.` 네트워크 설정 오류 해결 → 단순 네트워크 문제
- redis 네트워크 문제 → redis-cluster-entry 컨테이너에 `network_mode: "service:redis-master-1"` 삭제해서 해결
<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #101 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 