### PR TITLE
feat: 원하는 날짜로 일주일 독서량 조회 API 요청 가능하도록 수정

### DIFF
--- a/src/main/java/com/techeer/checkIt/domain/readingVolume/controller/ReadingVolumeController.java
+++ b/src/main/java/com/techeer/checkIt/domain/readingVolume/controller/ReadingVolumeController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,10 +29,13 @@ public class ReadingVolumeController {
     private final UserService userService;
 
     @ApiOperation(value = "일주일 독서량 조회 API")
-    @GetMapping("")
-    public ResponseEntity<ResultResponse> searchReadingVolumes(@AuthenticationPrincipal UserDetail userDetail) {
+    @GetMapping("{date}")
+    public ResponseEntity<ResultResponse> searchReadingVolumes(
+            @AuthenticationPrincipal UserDetail userDetail,
+            @PathVariable String date
+    ) {
         User user = userService.findUserByUsername(userDetail.getUsername());
-        List<SearchReadingVolumesRes> readingVolumeList = readingVolumeService.findReadingVolumesByUserAndDateBetween(user);
+        List<SearchReadingVolumesRes> readingVolumeList = readingVolumeService.findReadingVolumesByUserAndDateBetween(user, date);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.GET_READING_VOLUMES_SUCCESS,readingVolumeList));
     }
 }

--- a/src/main/java/com/techeer/checkIt/domain/readingVolume/service/ReadingVolumeService.java
+++ b/src/main/java/com/techeer/checkIt/domain/readingVolume/service/ReadingVolumeService.java
@@ -7,6 +7,7 @@ import com.techeer.checkIt.domain.readingVolume.exception.ReadingVolumeNotFoundE
 import com.techeer.checkIt.domain.readingVolume.mapper.ReadingVolumeMapper;
 import com.techeer.checkIt.domain.readingVolume.repository.ReadingVolumeRepository;
 import com.techeer.checkIt.domain.user.entity.User;
+import java.time.format.DateTimeFormatter;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,8 +24,9 @@ public class ReadingVolumeService {
     private final ReadingVolumeMapper readingVolumeMapper;
 
 
-    public List<SearchReadingVolumesRes> findReadingVolumesByUserAndDateBetween(User user) {
-        LocalDate end = LocalDate.now();
+    public List<SearchReadingVolumesRes> findReadingVolumesByUserAndDateBetween(User user, String date) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate end = LocalDate.parse(date, formatter);
         LocalDate start = end.minusDays(6);
         List<ReadingVolume> readingVolumes =
                 readingVolumeRepository.findByUserAndDateBetween(user,start,end);

--- a/src/test/java/com/techeer/checkIt/domain/readingVolume/controller/ReadingVolumeControllerTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/readingVolume/controller/ReadingVolumeControllerTest.java
@@ -59,12 +59,13 @@ class ReadingVolumeControllerTest {
         return objectMapper.writeValueAsString(object);
     }
 
+    // TEST_SEARCH_READINGVOLUME_RES 수정 필요 (api에서 원하는 날짜로 요청하도록 수정)
     @Test
     @DisplayName("일주일동안의 독서량을 보여준다")
     void searchReadingVolumes() throws Exception{
         when(userService.findUserById(1L)).thenReturn(TEST_USER);
         when(userService.findUserById(2L)).thenReturn(TEST_USER2);
-        when(readingVolumeService.findReadingVolumesByUserAndDateBetween(any())).thenReturn(List.of(TEST_SEARCH_READINGVOLUME_RES));
+        when(readingVolumeService.findReadingVolumesByUserAndDateBetween(any(), any())).thenReturn(List.of(TEST_SEARCH_READINGVOLUME_RES));
 
         mockMvc
                 .perform(

--- a/src/test/java/com/techeer/checkIt/domain/readingVolume/service/ReadingVolumeServiceTest.java
+++ b/src/test/java/com/techeer/checkIt/domain/readingVolume/service/ReadingVolumeServiceTest.java
@@ -36,6 +36,7 @@ class ReadingVolumeServiceTest {
     @Mock
     private ReadingVolumeMapper readingVolumeMapper;
 
+    // TEST_SEARCH_READINGVOLUME_RES 수정 필요 (api에서 원하는 날짜로 요청하도록 수정)
     @Test
     @DisplayName("user의 일주일 치 독서 기록을 반환한다.")
     void findReadingVolumesByUserAndDateBetween() {
@@ -49,7 +50,7 @@ class ReadingVolumeServiceTest {
 
         when(readingVolumeMapper.toDtoList(anyList())).thenReturn(list2);
 
-        List<SearchReadingVolumesRes> newList = readingVolumeService.findReadingVolumesByUserAndDateBetween(TEST_USER);
+        List<SearchReadingVolumesRes> newList = readingVolumeService.findReadingVolumesByUserAndDateBetween(TEST_USER, "2023-10-26");
 
         assertEquals(newList, list2);
 


### PR DESCRIPTION
## 📢 기능 설명 
![스크린샷 2023-10-26 오전 2 01 49](https://github.com/2023-Team-Joon-CheckIt/backend/assets/85063965/b3db9747-0201-4e4d-a482-aaab637f9ca1)
![스크린샷 2023-10-26 오전 2 04 16](https://github.com/2023-Team-Joon-CheckIt/backend/assets/85063965/20060b08-7dda-4ab2-a06d-671126acbd1e)

-> API 요청시 원하는 날짜를 파라미터로 요청하면 요청한 날짜로부터 앞으로 1주일 데이터를 반환

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #109 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 