### PR TITLE
[refactor/#117] 상태 별 책 목록 조회 API 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// queryDSL
+	implementation 'com.querydsl:querydsl-jpa'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -130,6 +136,16 @@ jacocoTestCoverageVerification {
 	}
 }
 
+// QueryDSL
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main {
+		java {
+			srcDirs = ['src/main/java', querydslDir]
+		}
+	}
+}
 
 test {
 	finalizedBy 'jacocoTestReport'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,111 @@
+version: "3"
+services:
+  redis-master-1:
+    container_name: redis-master-1
+    image: redis
+    volumes:
+      - ./redis/config/redis-master-1.conf:/etc/redis.conf
+    command: redis-server /etc/redis.conf
+    ports:
+      - 7001:7001
+      - 7002:7002
+      - 7003:7003
+      - 7101:7101
+      - 7102:7102
+      - 7103:7103
+
+  redis-master-2:
+    network_mode: "service:redis-master-1"
+    container_name: redis-master-2
+    image: redis
+    volumes:
+      - ./redis/config/redis-master-2.conf:/etc/redis.conf
+    command: redis-server /etc/redis.conf
+
+  redis-master-3:
+    network_mode: "service:redis-master-1"
+    container_name: redis-master-3
+    image: redis
+    volumes:
+      - ./redis/config/redis-master-3.conf:/etc/redis.conf
+    command: redis-server /etc/redis.conf
+
+  redis-slave-1:
+    network_mode: "service:redis-master-1"
+    container_name: redis-slave-1
+    image: redis
+    volumes:
+      - ./redis/config/redis-slave-1.conf:/etc/redis.conf
+    command: redis-server /etc/redis.conf
+
+  redis-slave-2:
+    network_mode: "service:redis-master-1"
+    container_name: redis-slave-2
+    image: redis
+    volumes:
+      - ./redis/config/redis-slave-2.conf:/etc/redis.conf
+    command: redis-server /etc/redis.conf
+
+  redis-slave-3:
+    network_mode: "service:redis-master-1"
+    container_name: redis-slave-3
+    image: redis
+    volumes:
+      - ./redis/config/redis-slave-3.conf:/etc/redis.conf
+    command: redis-server /etc/redis.conf
+
+  redis-cluster-entry:
+    network_mode: "service:redis-master-1"
+    image: redis
+    container_name: redis-cluster
+    command: redis-cli --cluster create 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7101 127.0.0.1:7102 127.0.0.1:7103 --cluster-replicas 1 --cluster-yes
+    depends_on:
+      - redis-master-1
+      - redis-master-2
+      - redis-master-3
+      - redis-slave-1
+      - redis-slave-2
+      - redis-slave-3
+
+  elasticsearch:
+    container_name: elasticsearch
+    restart: always
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.1
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - ES_JAVA_OPTS=-Xms2048m -Xmx2048m
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - ./elk/elasticsearch/data:/usr/share/elasticsearch/data
+    networks:
+      - default_bridge
+
+  logstash:
+    container_name: logstash
+    image: docker.elastic.co/logstash/logstash:8.8.1
+    build:
+      context: ./elk
+    volumes:
+      - ./elk/logstash/pipeline/logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+    ports:
+      - "5044:5044"
+    environment:
+      - "xpack.monitoring.enabled=false"
+    depends_on:
+      - elasticsearch
+    networks:
+      - default_bridge
+
+networks:
+  default_bridge:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.1.0/24

--- a/src/main/java/com/techeer/checkIt/domain/book/dto/Response/BookReadingRes.java
+++ b/src/main/java/com/techeer/checkIt/domain/book/dto/Response/BookReadingRes.java
@@ -2,14 +2,14 @@ package com.techeer.checkIt.domain.book.dto.Response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import com.querydsl.core.annotations.QueryProjection;
+import com.techeer.checkIt.domain.book.entity.Book;
+import lombok.*;
 
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class BookReadingRes {
   private Long id;
@@ -23,5 +23,21 @@ public class BookReadingRes {
   private int likes;
   private int lastPage;
   private Double percentage;
-  private Double grade;
+  private int grade;
+
+  @QueryProjection
+  public BookReadingRes(Book book, int grade) {
+    this.id = book.getId();
+    this.title = book.getTitle();
+    this.author = book.getAuthor();
+    this.publisher = book.getPublisher();
+    this.coverImageUrl = book.getCoverImageUrl();
+    this.height = book.getHeight();
+    this.width = book.getWidth();
+    this.pages = book.getPages();
+    this.likes = book.getLikeCount();
+    this.lastPage = book.getPages();
+    this.percentage = 100.0;
+    this.grade = grade;;
+  }
 }

--- a/src/main/java/com/techeer/checkIt/domain/book/dto/Response/BookReadingRes.java
+++ b/src/main/java/com/techeer/checkIt/domain/book/dto/Response/BookReadingRes.java
@@ -21,4 +21,7 @@ public class BookReadingRes {
   private int width;
   private int pages;
   private int likes;
+  private int lastPage;
+  private Double percentage;
+  private Double grade;
 }

--- a/src/main/java/com/techeer/checkIt/domain/book/entity/Book.java
+++ b/src/main/java/com/techeer/checkIt/domain/book/entity/Book.java
@@ -1,6 +1,7 @@
 package com.techeer.checkIt.domain.book.entity;
 
 import com.techeer.checkIt.domain.reading.entity.Reading;
+import com.techeer.checkIt.domain.review.entity.Review;
 import com.techeer.checkIt.entity.BaseEntity;
 import lombok.*;
 
@@ -36,7 +37,9 @@ public class Book extends BaseEntity {
     @Column(name = "category", length = 512)
     private String category;
     @OneToMany(mappedBy = "book")
-    private List<Reading> readingList = new ArrayList<>();
+    private List<Reading> readings = new ArrayList<>();
+    @OneToMany(mappedBy = "book")
+    private List<Review> reviews = new ArrayList<>();
     @Column(name = "like_count")
     private Integer likeCount = 0;
     @Builder

--- a/src/main/java/com/techeer/checkIt/domain/reading/dto/response/ReadingRes.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/dto/response/ReadingRes.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -14,6 +15,6 @@ import java.util.List;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReadingRes {
-    private List<BookReadingRes> bookInfos;
+    private Page<BookReadingRes> bookInfos;
     private ReadingStatus status;
 }

--- a/src/main/java/com/techeer/checkIt/domain/reading/mapper/ReadingMapper.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/mapper/ReadingMapper.java
@@ -80,10 +80,8 @@ public class ReadingMapper {
                 .build();
     }
 
-    public ReadingRes toReadingListByReview(List<Review> reviews, ReadingStatus status, Pageable pageable) {
-        Page<BookReadingRes> bookInfos = new PageImpl<>(reviews.stream()
-                                                                .map(reviewMapper::toDtoByReview)
-                                                                .collect(Collectors.toList()), pageable, reviews.size());
+    public ReadingRes toReadingListByReview(List<BookReadingRes> BookReading, ReadingStatus status, Pageable pageable) {
+        Page<BookReadingRes> bookInfos = new PageImpl<>(BookReading, pageable, BookReading.size());
 
         return ReadingRes.builder()
                 .bookInfos(bookInfos)

--- a/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepository.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepository.java
@@ -5,6 +5,7 @@ import com.techeer.checkIt.domain.reading.entity.Reading;
 import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
 import com.techeer.checkIt.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReadingRepository extends JpaRepository<Reading,Long>, ReadingRepositoryCustom {
+    @Query("SELECT r FROM Reading r LEFT JOIN FETCH r.book WHERE r.user.id = :userId AND r.status = :status")
     List<Reading> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") ReadingStatus status);
     Optional<Reading> findByUserIdAndBookIdAndStatus(Long userId, Long bookId, ReadingStatus status);
     Optional<Reading> findByUserAndBook(User user, Book book);

--- a/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepository.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import java.util.Optional;
 
-public interface ReadingRepository extends JpaRepository<Reading,Long> {
+public interface ReadingRepository extends JpaRepository<Reading,Long>, ReadingRepositoryCustom {
     List<Reading> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") ReadingStatus status);
     Optional<Reading> findByUserIdAndBookIdAndStatus(Long userId, Long bookId, ReadingStatus status);
     Optional<Reading> findByUserAndBook(User user, Book book);

--- a/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepositoryCustom.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.techeer.checkIt.domain.reading.repository;
+
+import com.techeer.checkIt.domain.book.dto.Response.BookReadingRes;
+import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
+
+import java.util.List;
+
+public interface ReadingRepositoryCustom {
+    List<BookReadingRes> findReadingsByUserIdAndStatus(Long userId, ReadingStatus status);
+}

--- a/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepositoryImpl.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/repository/ReadingRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.techeer.checkIt.domain.reading.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.techeer.checkIt.domain.book.dto.Response.BookReadingRes;
+import com.techeer.checkIt.domain.book.dto.Response.QBookReadingRes;
+import com.techeer.checkIt.domain.book.entity.QBook;
+import com.techeer.checkIt.domain.reading.entity.QReading;
+import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
+import com.techeer.checkIt.domain.review.entity.QReview;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ReadingRepositoryImpl implements ReadingRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<BookReadingRes> findReadingsByUserIdAndStatus(Long userId, ReadingStatus status) {
+        QReading qReading = QReading.reading;
+        QBook qBook = QBook.book;
+        QReview qReview = QReview.review;
+
+        return queryFactory
+                .select(new QBookReadingRes(
+                        qBook,
+                        qReview.grade.coalesce(0)))
+                .from(qReading)
+                .leftJoin(qReading.book, qBook)
+                .leftJoin(qBook.reviews, qReview)
+                .where(qReading.user.id.eq(userId)
+                        .and(qReading.status.eq(status)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
@@ -62,7 +62,7 @@ public class ReadingService {
     }
 
     public ReadingRes findReadingByStatus(Long userId, ReadingStatus status) {
-        PageRequest pageRequest = PageRequest.of(0, 16, Sort.by(Sort.Order.desc("createdAt")));
+        PageRequest pageRequest = PageRequest.of(0, 18, Sort.by(Sort.Order.desc("updatedAt")));
         if (status.toString().equals("LIKE")) {
             List<Book> readings = new ArrayList<>();
             String redisUserKey = "U" + userId.toString();

--- a/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
+++ b/src/main/java/com/techeer/checkIt/domain/reading/service/ReadingService.java
@@ -1,6 +1,7 @@
 package com.techeer.checkIt.domain.reading.service;
 
 import com.techeer.checkIt.domain.book.dao.RedisDao;
+import com.techeer.checkIt.domain.book.dto.Response.BookReadingRes;
 import com.techeer.checkIt.domain.book.entity.Book;
 import com.techeer.checkIt.domain.book.repository.BookJpaRepository;
 import com.techeer.checkIt.domain.reading.dto.request.CreateReadingReq;
@@ -19,7 +20,6 @@ import com.techeer.checkIt.domain.reading.repository.ReadingRepository;
 import com.techeer.checkIt.domain.readingVolume.entity.ReadingVolume;
 import com.techeer.checkIt.domain.readingVolume.mapper.ReadingVolumeMapper;
 import com.techeer.checkIt.domain.readingVolume.service.ReadingVolumeService;
-import com.techeer.checkIt.domain.review.entity.Review;
 import com.techeer.checkIt.domain.review.repository.ReviewRepository;
 import com.techeer.checkIt.domain.user.entity.User;
 import java.util.ArrayList;
@@ -44,7 +44,6 @@ public class ReadingService {
     private final ReadingVolumeMapper readingVolumeMapper;
     private final RedisDao redisDao;
     private final BookJpaRepository bookJpaRepository;
-    private final ReviewRepository reviewRepository;
 
     public int registerReading(User user, Book book, CreateReadingReq createRequest){
         ReadingStatus status = ReadingStatus.convert(createRequest.getStatus().toUpperCase());
@@ -76,11 +75,10 @@ public class ReadingService {
             readings = readingRepository.findByUserIdAndStatus(userId ,status);
             return readingMapper.toReadingList(readings, status, pageRequest);
         } else {
-            List<Review> readings = new ArrayList<>();
-            readings = reviewRepository.findByUserId(userId);
+            List<BookReadingRes> readings = new ArrayList<>();
+            readings = readingRepository.findReadingsByUserIdAndStatus(userId, status);
             return readingMapper.toReadingListByReview(readings, status, pageRequest);
         }
-
     }
 
     public void updateReadingStatus(Long userId, Long bookId, ReadingStatus status, UpdateReadingStatusReq updateStatus) {

--- a/src/main/java/com/techeer/checkIt/domain/review/dto/request/CreateReviewReq.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/dto/request/CreateReviewReq.java
@@ -17,5 +17,5 @@ public class CreateReviewReq {
   private long bookId;
   private String title;
   private String content;
-  private Double grade;
+  private int grade;
 }

--- a/src/main/java/com/techeer/checkIt/domain/review/dto/response/ReviewRes.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/dto/response/ReviewRes.java
@@ -14,5 +14,5 @@ import lombok.Getter;
 public class ReviewRes {
   private String title;
   private String content;
-  private Double grade;
+  private int grade;
 }

--- a/src/main/java/com/techeer/checkIt/domain/review/entity/Review.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/entity/Review.java
@@ -31,11 +31,11 @@ public class Review extends BaseEntity {
   @Column(nullable = false, length = 255)
   private String contents;
 
-  @Column(columnDefinition = "double default 0")
-  private Double grade;
+  @Column(columnDefinition = "int default 0")
+  private int grade;
 
   @Builder
-  public Review(User user, Book book, String title, String contents, Double grade, Boolean isDeleted) {
+  public Review(User user, Book book, String title, String contents, int grade) {
     this.user = user;
     this.book = book;
     this.title = title;

--- a/src/main/java/com/techeer/checkIt/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/mapper/ReviewMapper.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReviewMapper {
 
-  public Review toEntity(User user, Book book, String title, String contents, Double grade) {
+  public Review toEntity(User user, Book book, String title, String contents, int grade) {
     return Review.builder()
         .user(user)
         .book(book)
@@ -26,22 +26,5 @@ public class ReviewMapper {
         .content(review.getContents())
         .grade(review.getGrade())
         .build();
-  }
-
-  public BookReadingRes toDtoByReview(Review review) {
-    return BookReadingRes.builder()
-            .id(review.getBook().getId())
-            .title(review.getBook().getTitle())
-            .author(review.getBook().getAuthor())
-            .publisher(review.getBook().getPublisher())
-            .coverImageUrl(review.getBook().getCoverImageUrl())
-            .height(review.getBook().getHeight())
-            .width(review.getBook().getWidth())
-            .pages(review.getBook().getPages())
-            .likes(review.getBook().getLikeCount())
-            .lastPage(review.getBook().getPages())
-            .percentage(100.0)
-            .grade(review.getGrade())
-            .build();
   }
 }

--- a/src/main/java/com/techeer/checkIt/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/mapper/ReviewMapper.java
@@ -1,5 +1,6 @@
 package com.techeer.checkIt.domain.review.mapper;
 
+import com.techeer.checkIt.domain.book.dto.Response.BookReadingRes;
 import com.techeer.checkIt.domain.book.entity.Book;
 import com.techeer.checkIt.domain.review.dto.response.ReviewRes;
 import com.techeer.checkIt.domain.review.entity.Review;
@@ -27,4 +28,20 @@ public class ReviewMapper {
         .build();
   }
 
+  public BookReadingRes toDtoByReview(Review review) {
+    return BookReadingRes.builder()
+            .id(review.getBook().getId())
+            .title(review.getBook().getTitle())
+            .author(review.getBook().getAuthor())
+            .publisher(review.getBook().getPublisher())
+            .coverImageUrl(review.getBook().getCoverImageUrl())
+            .height(review.getBook().getHeight())
+            .width(review.getBook().getWidth())
+            .pages(review.getBook().getPages())
+            .likes(review.getBook().getLikeCount())
+            .lastPage(review.getBook().getPages())
+            .percentage(100.0)
+            .grade(review.getGrade())
+            .build();
+  }
 }

--- a/src/main/java/com/techeer/checkIt/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/techeer/checkIt/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,9 @@
 package com.techeer.checkIt.domain.review.repository;
 
+import com.techeer.checkIt.domain.reading.entity.ReadingStatus;
 import com.techeer.checkIt.domain.review.entity.Review;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +13,6 @@ import org.springframework.data.repository.query.Param;
 public interface ReviewRepository extends JpaRepository<Review,Long> {
   @Query("select r from Review r where r.user.nickname LIKE :userName AND r.book.id = :bookId AND r.isDeleted = false")
   Optional<Review> findByUserNameBookId(@Param("userName") String userName, @Param("bookId") Long bookId);
+
+  List<Review> findByUserId(Long userId);
 }

--- a/src/main/java/com/techeer/checkIt/domain/user/entity/User.java
+++ b/src/main/java/com/techeer/checkIt/domain/user/entity/User.java
@@ -37,10 +37,10 @@ public class User extends BaseEntity {
     private boolean isActive = true; // 활성 여부
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Reading> readingList = new ArrayList<>();
+    private List<Reading> readings = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ReadingVolume> readingVolumeList = new ArrayList<>();
+    private List<ReadingVolume> readingVolumes = new ArrayList<>();
 
     @Builder
     private User(String username, String nickname, String password, Role role) {

--- a/src/main/java/com/techeer/checkIt/global/config/QueryDSLConfig.java
+++ b/src/main/java/com/techeer/checkIt/global/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.techeer.checkIt.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDSLConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명 
### READING; LastPage, percetage 반환
<img width="633" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/f1bfc234-677f-4378-a89d-b14e604ed9fb">

### READ; Grade 반환 
<img width="670" alt="image" src="https://github.com/2023-Team-Joon-CheckIt/backend/assets/101381901/72618004-56a3-4ad5-9774-8f81e3f47875">

- grade 타입 int형으로 변경
- Querydsl 도입 
- fetch join을 통해 N+1 문제 해결 

<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #117 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 